### PR TITLE
update plot_pca.py to items(), iteritems deprecated() in pandas v1.5.0

### DIFF
--- a/qadabra/workflow/scripts/plot_pca.py
+++ b/qadabra/workflow/scripts/plot_pca.py
@@ -99,7 +99,7 @@ ax.legend(
 
 prop_exp_labels = [
     f"{i} ({x*100:.2f}%)"
-    for i, x in prop_exp.iteritems()
+    for i, x in prop_exp.items()
 ]
 ax.set_xlabel(prop_exp_labels[0])
 ax.set_ylabel(prop_exp_labels[1])


### PR DESCRIPTION
Failed on rule plot_pca:
AttributeError: 'Series' object has no attribute 'iteritems'

See pandas v1.5.0 documentation on iteritems() deprecation: https://pandas.pydata.org/docs/dev/whatsnew/v1.5.0.html
https://github.com/pandas-dev/pandas/pull/45321