### PR TITLE
EMPress integration, addressing pandas FutureWarning, minor changes/additions to code documentation and variable names

### DIFF
--- a/qadabra/utils.py
+++ b/qadabra/utils.py
@@ -67,4 +67,6 @@ def _validate_input(
         tbl_features = set(tbl.ids("observation"))
         if not tip_names.issubset(tbl_features):
             raise ValueError("Tree tips are not a subset of table features!")
-        
+    else:
+        logger.info("Reading phylogenetic tree...")
+        logger.info("(Optional tree file not provided. Skipping tree validation.)")

--- a/qadabra/utils.py
+++ b/qadabra/utils.py
@@ -49,7 +49,7 @@ def _validate_input(
     logger.info("Looking for completely discriminatory taxa...")
     tbl_df = tbl.to_dataframe(dense=True).T
     joint_df = tbl_df.join(md)
-    gb = joint_df.groupby(factor_name).sum()
+    gb = joint_df.groupby(factor_name).sum(numeric_only=True)
     feat_presence = gb.apply(lambda x: x.all())
     if not feat_presence.all():
         raise ValueError(
@@ -59,7 +59,6 @@ def _validate_input(
 
     if tree:
         from bp import parse_newick, to_skbio_treenode
-
         logger.info("Reading phylogenetic tree...")
         with open(tree) as f:
             tr = parse_newick(f.readline())
@@ -68,3 +67,4 @@ def _validate_input(
         tbl_features = set(tbl.ids("observation"))
         if not tip_names.issubset(tbl_features):
             raise ValueError("Tree tips are not a subset of table features!")
+        

--- a/qadabra/workflow/envs/qadabra-empress.yaml
+++ b/qadabra/workflow/envs/qadabra-empress.yaml
@@ -1,0 +1,8 @@
+channels:
+    - conda-forge
+    - bioconda
+dependencies:
+    - pip:
+        - cython
+        - numpy >= 1.12.0
+        - empress

--- a/qadabra/workflow/rules/common.smk
+++ b/qadabra/workflow/rules/common.smk
@@ -33,13 +33,13 @@ def get_diffab_tool_columns(wildcards):
 
     columns = {
         "edger": f"{covariate}{target}",
-        "deseq2": "logFC",
+        "deseq2": "log2FoldChange",
         "ancombc": "coefs",
-        "aldex2": "logFC",
+        "aldex2": f"model.{covariate}{target} Estimate",
         "songbird": f"C({covariate}, Treatment('{reference}'))[T.{target}]",
         "maaslin2": "coef",
-        "metagenomeseq": "coefs",
-        "corncob": "logFC",
+        "metagenomeseq": f"{covariate}{target}",
+        "corncob": "coefs",
     }
     return columns[wildcards.tool]
 
@@ -52,12 +52,12 @@ def get_pvalue_tool_columns(wildcards):
 
     columns = {
         "edger": "PValue",
-        "deseq2": "PValue",
-        "ancombc": "PValue",
-        "aldex2": "PValue",
-        "maaslin2": "PValue",
-        "metagenomeseq": "PValue",
-        "corncob": "PValue",
+        "deseq2": "pvalue",
+        "ancombc": "pvals",
+        "aldex2": f"model.{covariate}{target} Pr(>|t|)",
+        "maaslin2": "pval",
+        "metagenomeseq": "pvalues",
+        "corncob": "fit.p",
     }
     return columns[wildcards.tool]
 

--- a/qadabra/workflow/rules/common.smk
+++ b/qadabra/workflow/rules/common.smk
@@ -60,7 +60,7 @@ def get_pvalue_tool_columns(wildcards):
         "corncob": "fit.p",
     }
     return columns[wildcards.tool]
-
+      
 all_differentials = expand(
     "results/{dataset}/{out}",
     dataset=names,
@@ -71,6 +71,12 @@ all_pvalues = expand(
     "results/{dataset}/{out}",
     dataset=names,
     out=["concatenated_pvalues.tsv", "pvalues_table.html"]
+)
+
+all_results = expand(
+    "results/{dataset}/{out}",
+    dataset=names,
+    out=["qadabra_all_result.tsv"]
 )
 
 pvalue_volcanoes = expand(
@@ -111,4 +117,13 @@ all_viz_files.extend(expand(
     curve=["pr", "roc"],
 ))
 
-all_input = all_differentials + all_pvalues + pvalue_volcanoes + all_viz_files + all_ml + all_diff_viz
+all_input = all_differentials + all_pvalues + pvalue_volcanoes + all_viz_files + all_ml + all_diff_viz + all_results
+
+for dataset in datasets.iterrows():
+    if not pd.isna(dataset[1]['tree']):
+        empress_output = expand(
+            "results/{dataset}/{out}",
+            dataset=names,
+            out=["empress"]
+            )
+        all_input = all_input + empress_output

--- a/qadabra/workflow/rules/diffab.smk
+++ b/qadabra/workflow/rules/diffab.smk
@@ -162,7 +162,7 @@ rule process_differentials:
         "../scripts/process_differentials.py"
 
 
-rule combine_differentials:
+rule concatenate_differentials:
     input:
         expand(
             "results/{{dataset}}/tools/{tool}/differentials.processed.tsv",
@@ -171,7 +171,7 @@ rule combine_differentials:
     output:
         "results/{dataset}/concatenated_differentials.tsv",
     log:
-        "log/{dataset}/combine_differentials.log",
+        "log/{dataset}/concatenate_differentials.log",
     conda:
         "../envs/qadabra-default.yaml"
     script:
@@ -207,3 +207,17 @@ rule concatenate_pvalues:
         "../envs/qadabra-default.yaml"
     script:
         "../scripts/concatenate_pvalues.py"
+
+
+rule concatenate_all_results:
+    input:
+        concatenated_pvalues="results/{dataset}/concatenated_pvalues.tsv",
+        concatenated_differentials="results/{dataset}/concatenated_differentials.tsv",
+    output:
+        "results/{dataset}/qadabra_all_result.tsv",
+    log:
+        "log/{dataset}/qadabra_all_result.log",
+    conda:
+        "../envs/qadabra-default.yaml"
+    script:
+        "../scripts/concatenate_all_results.py"

--- a/qadabra/workflow/rules/visualization.smk
+++ b/qadabra/workflow/rules/visualization.smk
@@ -1,5 +1,6 @@
 stylesheet = config["stylesheet"]
 
+datasets = pd.read_table("config/datasets.tsv", sep="\t", index_col=0)
 
 rule plot_differentials:
     input:
@@ -229,6 +230,30 @@ rule qurro:
             --ranks {input.ranks} \
             --table {input.table} \
             --sample-metadata {input.metadata} \
+            --output-dir {output} > {log} 2>&1
+        """
+
+
+rule empress:
+    input:
+        unpack(lambda wc: get_dataset_cfg(wc, ["tree"])),
+        ranks="results/{dataset}/qadabra_all_result.tsv",
+    output:
+        report(
+            directory("results/{dataset}/empress"),
+            caption="../report/empress.rst",
+            htmlindex="empress.html",
+            category="EMPress plot",
+        ),
+    log:
+        "log/{dataset}/empress.log",
+    conda:
+        "../envs/qadabra-empress.yaml"
+    shell:
+        """
+        empress tree-plot \
+            --tree {input.tree} \
+            --feature-metadata {input.ranks} \
             --output-dir {output} > {log} 2>&1
         """
 

--- a/qadabra/workflow/rules/visualization.smk
+++ b/qadabra/workflow/rules/visualization.smk
@@ -198,6 +198,9 @@ rule plot_pvalue_volcanoes:
         ),
     log:
         "log/{dataset}/plot_pvalue_volcanoes.{tool}.log",
+    params:
+        pval_col=get_pvalue_tool_columns,
+        diff_ab_col=get_diffab_tool_columns,
     conda:
         "../envs/qadabra-default.yaml"
     script:

--- a/qadabra/workflow/scripts/R/aldex2.R
+++ b/qadabra/workflow/scripts/R/aldex2.R
@@ -1,14 +1,17 @@
 library(biomformat)
 library(ALDEx2)
 
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 
+# Load the metadata
 print("Loading metadata...")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -18,6 +21,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -25,9 +29,9 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 table <- table[, sample_order]
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 
+# Create the design formula
 print("Creating design formula...")
 design.formula <- paste0("~", covariate)
 if (length(confounders) != 0) {
@@ -35,17 +39,19 @@ if (length(confounders) != 0) {
     design.formula <- paste0(design.formula, " + ", confounders_form)
 }
 design.formula <- as.formula(design.formula)
-print(design.formula)
 mm <- model.matrix(design.formula, metadata)
 
+# Run ALDEx2
 print("Running ALDEx2...")
-x <- ALDEx2::aldex.clr(table, mm)
-aldex2.results <- ALDEx2::aldex.glm(x)
+x <- ALDEx2::aldex.clr(table, mm) # perform CLR transformation
+aldex2.results <- ALDEx2::aldex.glm(x) # apply generalized linear model
 saveRDS(aldex2.results, snakemake@output[[2]])
 print("Saved RDS!")
 
+# Modify result names
 row.names(aldex2.results) <- gsub("^F_", "", row.names(aldex2.results))
-colnames(aldex2.results)[c(5, 8)] <- c("logFC", "PValue")
+target <- paste(covariate, target, sep = "")
 
+# Save results to output file
 write.table(aldex2.results, file=snakemake@output[[1]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/R/ancombc.R
+++ b/qadabra/workflow/scripts/R/ancombc.R
@@ -52,17 +52,20 @@ ancombc.results <- ANCOMBC::ancombc(phyloseq=physeq, formula=design.formula, zer
 saveRDS(ancombc.results, snakemake@output[[2]])
 print("Saved RDS!")
 
+# Access coefficients and p-values from the ANCOMBC results
+coef_col <- paste("coefs", covariate, target, sep = ".")
+pval_col <- paste("pvals", covariate, target, sep = ".")
 coefs <- ancombc.results$res$beta
 pvals <- ancombc.results$res$p_val
-qvals <- ancombc.results$res$q_val
+# qvals <- ancombc.results$res$q_val
 
 # Modify result names
 row.names(coefs) <- gsub("^F_", "", row.names(coefs))
 row.names(pvals) <- gsub("^F_", "", row.names(pvals))
-row.names(qvals) <- gsub("^F_", "", row.names(qvals))
+# row.names(qvals) <- gsub("^F_", "", row.names(qvals))
 
-results_all <- data.frame(coefs=coefs, pvals=pvals, qvals=qvals)
-colnames(results_all)[1:3] <- c("coefs", "pvals", "qvals")
+results_all <- data.frame(coefs=coefs, pvals=pvals)
+colnames(results_all) <- c("coefs", "pvals")
 
 # Save results to output file
 write.table(results_all, file=snakemake@output[[1]], sep="\t")

--- a/qadabra/workflow/scripts/R/ancombc.R
+++ b/qadabra/workflow/scripts/R/ancombc.R
@@ -2,14 +2,17 @@ library(biomformat)
 library(ANCOMBC)
 library(phyloseq)
 
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 
+# Load the metadata
 print("Loading metadata...")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -19,6 +22,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -26,14 +30,15 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 table <- table[, sample_order]
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 
+# Convert to phyloseq object
 print("Converting to phyloseq...")
 taxa <- phyloseq::otu_table(table, taxa_are_rows=T)
 meta <- phyloseq::sample_data(metadata)
 physeq <- phyloseq::phyloseq(taxa, meta)
 
+# Create the design formula
 print("Creating design formula...")
 design.formula <- covariate
 if (length(confounders) != 0) {
@@ -41,32 +46,24 @@ if (length(confounders) != 0) {
     design.formula <- paste0(design.formula, " + ", confounders_form)
 }
 
+# Run ANCOMBC
 print("Running ANCOMBC...")
-ancombc.results <- ANCOMBC::ancombc(phyloseq=physeq, formula=design.formula, zero_cut=1.0)
-
+ancombc.results <- ANCOMBC::ancombc(phyloseq=physeq, formula=design.formula, zero_cut=1.0, p_adj_method = "BH",)
 saveRDS(ancombc.results, snakemake@output[[2]])
 print("Saved RDS!")
-results <- ancombc.results$res$beta
+
+coefs <- ancombc.results$res$beta
 pvals <- ancombc.results$res$p_val
 qvals <- ancombc.results$res$q_val
 
-row.names(results) <- gsub("^F_", "", row.names(results))
+# Modify result names
+row.names(coefs) <- gsub("^F_", "", row.names(coefs))
 row.names(pvals) <- gsub("^F_", "", row.names(pvals))
 row.names(qvals) <- gsub("^F_", "", row.names(qvals))
 
-results_all <- data.frame(coef=results, pvals=pvals, qvals=qvals)
-colnames(results_all) <- c("coefs", "PValue", "qvals")
+results_all <- data.frame(coefs=coefs, pvals=pvals, qvals=qvals)
+colnames(results_all)[1:3] <- c("coefs", "pvals", "qvals")
 
-results_all$logFC <- results_all$coefs
-
+# Save results to output file
 write.table(results_all, file=snakemake@output[[1]], sep="\t")
-# print("Running ANCOMBC...")
-# ancombc.results <- ANCOMBC::ancombc(phyloseq=physeq, formula=design.formula,
-#                                     zero_cut=1.0)
-# saveRDS(ancombc.results, snakemake@output[[2]])
-# print("Saved RDS!")
-# results <- ancombc.results$res$beta
-# row.names(results) <- gsub("^F_", "", row.names(results))
-
-# write.table(results, file=snakemake@output[[1]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/R/corncob.R
+++ b/qadabra/workflow/scripts/R/corncob.R
@@ -2,14 +2,17 @@ library(biomformat)
 library(corncob)
 library(phyloseq)
 
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 
+# Load the metadata
 print("Loading metadata...")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -19,6 +22,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -26,14 +30,15 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 table <- table[, sample_order]
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 
+# Convert to phyloseq object
 print("Converting to phyloseq...")
 taxa <- phyloseq::otu_table(table, taxa_are_rows=T)
 meta <- phyloseq::sample_data(metadata)
 physeq <- phyloseq::phyloseq(taxa, meta)
 
+# Create the design formula
 print("Creating design formula...")
 design.formula <- paste0("~", covariate)
 if (length(confounders) != 0) {
@@ -43,6 +48,7 @@ if (length(confounders) != 0) {
 design.formula <- as.formula(design.formula)
 print(design.formula)
 
+# Run Corncob
 print("Running corncob...")
 fit <- corncob::differentialTest(
     formula=design.formula,
@@ -58,6 +64,7 @@ fit <- corncob::differentialTest(
 saveRDS(fit, snakemake@output[[2]])
 print("Saved RDS!")
 
+# Create results table
 taxa_names <- names(fit$p)
 colname <- paste0("mu.", covariate, target)
 
@@ -72,12 +79,12 @@ coefs <- as.data.frame(coefs)
 row.names(coefs) <- taxa_names
 row.names(coefs) <- gsub("^F_", "", row.names(coefs))
 
-print("printing pvalues")
 pvals <- as.data.frame(fit$p)
+adjusted_p_values <- p.adjust(fit$p, method = "BH")
+pval_BH_adj <- as.data.frame(adjusted_p_values)
 
-results_all <- data.frame(coefs=coefs, pvals=pvals)
-colnames(results_all) <- c("logFC", "PValue")
-# results_all$logFC <- results_all$coefs
+results_all <- data.frame(coefs=coefs, pvals=pvals, pval_BH_adj=pval_BH_adj)
 
+# Save results to output file
 write.table(results_all, snakemake@output[[1]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/R/deseq2.R
+++ b/qadabra/workflow/scripts/R/deseq2.R
@@ -1,14 +1,17 @@
 library(biomformat)
 library(DESeq2)
 
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 
+# Load the metadata
 print("Loading metadata...")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -18,6 +21,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -25,9 +29,9 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 table <- table[, sample_order]
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 
+# Create the design formula
 print("Creating design formula...")
 design.formula <- paste0("~", covariate)
 if (length(confounders) != 0) {
@@ -35,8 +39,8 @@ if (length(confounders) != 0) {
     design.formula <- paste0(design.formula, " + ", confounders_form)
 }
 design.formula <- as.formula(design.formula)
-print(design.formula)
 
+# Run DESeq2
 print("Running DESeq2...")
 dds <- DESeq2::DESeqDataSetFromMatrix(
     countData=table,
@@ -47,15 +51,17 @@ dds.results <- DESeq2::DESeq(dds, sfType="poscounts")
 saveRDS(dds.results, snakemake@output[[2]])
 print("Saved RDS!")
 
+# Create results table and modify result names
 results <- DESeq2::results(
     dds.results,
     format="DataFrame",
     tidy=TRUE,
     cooksCutoff=FALSE,
+    pAdjustMethod="BH",
     contrast=c(covariate, target, reference)
 )
 row.names(results) <- gsub("^F_", "", row.names(table))
-colnames(results)[c(3,6)] <- c("logFC", "PValue")
 
+# Save results to output file
 write.table(results, file=snakemake@output[[1]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/R/maaslin2.R
+++ b/qadabra/workflow/scripts/R/maaslin2.R
@@ -58,7 +58,7 @@ results <- results %>% select(-c("feature"))
 # Extract coefficient, p-value, and adjusted p-value results
 adjusted_p_values <- p.adjust(results$pval, method = "BH")
 results$pval_BH_adj <- adjusted_p_values
-results$coef <- log2(exp(results$coef))
+# results$coef <- results$coef
 
 # Save results to output file
 write.table(results, file=snakemake@output[["diff_file"]], sep="\t")

--- a/qadabra/workflow/scripts/R/maaslin2.R
+++ b/qadabra/workflow/scripts/R/maaslin2.R
@@ -2,14 +2,17 @@ library(biomformat)
 library(dplyr)
 library(Maaslin2)
 
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 
+# Load the metadata
 print("Loading metadata")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -19,6 +22,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -26,16 +30,13 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+# Create results table and modify result names
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 table <- t(table[, sample_order])
-
 fixed.effects <- c(covariate, confounders)
-print(fixed.effects)
-
 specify.reference <- paste(covariate, reference, sep = ",", collapse = ",")
-print(specify.reference)
 
+# Run maAsLin
 print("Running MaAsLin...")
 fit.data <- Maaslin2::Maaslin2(
     input_data=table,
@@ -53,9 +54,12 @@ results <- results %>% distinct(feature, .keep_all = TRUE)
 
 row.names(results) <- gsub("^F_", "", results$feature)
 results <- results %>% select(-c("feature"))
-colnames(results)[c(5)] <- c("PValue")
 
-results$logFC <- log2(exp(results$coef))
+# Extract coefficient, p-value, and adjusted p-value results
+adjusted_p_values <- p.adjust(results$pval, method = "BH")
+results$pval_BH_adj <- adjusted_p_values
+results$coef <- log2(exp(results$coef))
 
+# Save results to output file
 write.table(results, file=snakemake@output[["diff_file"]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/R/metagenomeseq.R
+++ b/qadabra/workflow/scripts/R/metagenomeseq.R
@@ -2,16 +2,18 @@ library(biomformat)
 library(Biobase)
 library(metagenomeSeq)
 
-
+# Set logging information
 log <- file(snakemake@log[[1]], open="wt")
 sink(log)
 sink(log, type="message")
 
+# Load the input table
 print("Loading table...")
 table <- biomformat::read_biom(snakemake@input[["table"]])
 table <- as.matrix(biomformat::biom_data(table))
 table <- as.data.frame(table)
 
+# Load the metadata
 print("Loading metadata...")
 metadata <- read.table(snakemake@input[["metadata"]], sep="\t", header=T,
                        row.names=1)
@@ -21,6 +23,7 @@ target <- snakemake@params[[1]][["target_level"]]
 reference <- snakemake@params[[1]][["reference_level"]]
 confounders <- snakemake@params[[1]][["confounders"]]
 
+# Harmonize table and metadata samples
 print("Harmonizing table and metadata samples...")
 samples <- colnames(table)
 metadata <- subset(metadata, rownames(metadata) %in% samples)
@@ -28,20 +31,23 @@ metadata[[covariate]] <- as.factor(metadata[[covariate]])
 metadata[[covariate]] <- relevel(metadata[[covariate]], reference)
 sample_order <- row.names(metadata)
 table <- table[, sample_order]
-# Append F_ to features to avoid R renaming
-row.names(table) <- paste0("F_", row.names(table))
+row.names(table) <- paste0("F_", row.names(table)) # Append F_ to features to avoid R renaming
 
+# Create AnnotatedDataFrame from metadata
 pheno <- Biobase::AnnotatedDataFrame(metadata)
 
+# Create MRexperiment object
 experiment <- metagenomeSeq::newMRexperiment(
     counts=table,
     phenoData=pheno,
 )
 
+# Perform cumulative sum scaling (CSS) normalization
 pctile <- metagenomeSeq::cumNormStat(experiment, pFlag=T)
 experiment_norm <- metagenomeSeq::cumNorm(experiment, p=pctile)
 pd <- Biobase::pData(experiment_norm)
 
+# Create design formula for model matrix
 print("Creating design formula...")
 design.formula <- paste0("~", covariate)
 if (length(confounders) != 0) {
@@ -52,22 +58,23 @@ if (length(confounders) != 0) {
     design.formula <- paste0(design.formula, " + ", confounders_form)
 }
 design.formula <- as.formula(design.formula)
-print(design.formula)
 
 mm <- model.matrix(design.formula, data=pd)
+
+# Run MetagenomeSeq
 print("Running metagenomeSeq...")
 fit <- metagenomeSeq::fitZig(experiment_norm, mm)
-
 saveRDS(fit, snakemake@output[[2]])
 print("Saved RDS!")
 
+# Create results table and modify results names
 results <- metagenomeSeq::MRcoefs(
     obj=fit,
-    number=dim(table)[1]
+    number=dim(table)[1],
+    adjustMethod="BH",
 )
 row.names(results) <- gsub("^F_", "", row.names(results))
-colnames(results)[c(2, 4)] <- c("coefs", "PValue")
-results$logFC <- results$coefs
 
+# Save results to output file
 write.table(results, file=snakemake@output[[1]], sep="\t")
 print("Saved differentials!")

--- a/qadabra/workflow/scripts/concatenate_all_results.py
+++ b/qadabra/workflow/scripts/concatenate_all_results.py
@@ -27,7 +27,7 @@ for index, row in qadabra_all_result.iterrows():
         if col.endswith("_p-values"):
             if row[col] < 0.05:
                 count += 1
-    qadabra_all_result.loc[index, "significant_num_tools"] = count
+    qadabra_all_result.loc[index, "# of tools p > 0.05"] = count
 
 
 qadabra_all_result.to_csv(snakemake.output[0], sep="\t", index=True)

--- a/qadabra/workflow/scripts/concatenate_all_results.py
+++ b/qadabra/workflow/scripts/concatenate_all_results.py
@@ -1,0 +1,34 @@
+import logging
+import pandas as pd
+
+logger = logging.getLogger("qadabra")
+logger.setLevel(logging.INFO)
+fh = logging.FileHandler(snakemake.log[0], mode="w")
+formatter = logging.Formatter(
+    f"[%(asctime)s - {snakemake.rule}] :: %(message)s"
+)
+fh.setFormatter(formatter)
+logger.addHandler(fh)
+
+logging.captureWarnings(True)
+logging.getLogger("py.warnings").addHandler(fh)
+
+logger.info("Loading differentials...")
+concatenated_diff_file = pd.read_csv(snakemake.input["concatenated_differentials"], sep="\t", index_col=0)
+
+logger.info("Loading p-values...")
+concatenated_pvalue_file = pd.read_csv(snakemake.input["concatenated_pvalues"], sep="\t", index_col=0)
+
+qadabra_all_result = pd.concat([concatenated_diff_file, concatenated_pvalue_file], axis=1)
+
+for index, row in qadabra_all_result.iterrows():
+    count = 0
+    for col in qadabra_all_result.columns:
+        if col.endswith("_p-values"):
+            if row[col] < 0.05:
+                count += 1
+    qadabra_all_result.loc[index, "significant_num_tools"] = count
+
+
+qadabra_all_result.to_csv(snakemake.output[0], sep="\t", index=True)
+

--- a/qadabra/workflow/scripts/concatenate_all_results.py
+++ b/qadabra/workflow/scripts/concatenate_all_results.py
@@ -16,18 +16,30 @@ logging.getLogger("py.warnings").addHandler(fh)
 logger.info("Loading differentials...")
 concatenated_diff_file = pd.read_csv(snakemake.input["concatenated_differentials"], sep="\t", index_col=0)
 
+for col in concatenated_diff_file.columns:
+    new_col_name = col + " differentials"
+    concatenated_diff_file.rename(columns={col: new_col_name}, inplace=True)
+    
 logger.info("Loading p-values...")
 concatenated_pvalue_file = pd.read_csv(snakemake.input["concatenated_pvalues"], sep="\t", index_col=0)
+
+for col in concatenated_pvalue_file.columns:
+    new_col_name = col + " significant features"
+    concatenated_pvalue_file.rename(columns={col: new_col_name}, inplace=True)
+
 
 qadabra_all_result = pd.concat([concatenated_diff_file, concatenated_pvalue_file], axis=1)
 
 for index, row in qadabra_all_result.iterrows():
     count = 0
     for col in qadabra_all_result.columns:
-        if col.endswith("_p-values"):
+        if col.endswith(" significant features"):
             if row[col] < 0.05:
                 count += 1
-    qadabra_all_result.loc[index, "# of tools p > 0.05"] = count
+                qadabra_all_result.at[index, col] = "p<0.05"
+            else:
+                qadabra_all_result.at[index, col] = "ns"
+    qadabra_all_result.at[index, "# of tools p > 0.05"] = count
 
 
 qadabra_all_result.to_csv(snakemake.output[0], sep="\t", index=True)

--- a/qadabra/workflow/scripts/concatenate_differentials.py
+++ b/qadabra/workflow/scripts/concatenate_differentials.py
@@ -20,7 +20,7 @@ diffs_files = [
 concat_diffs = pd.concat(diffs_files, axis=1)
 
 for col in concat_diffs.columns:
-    new_col_name = col + "_effect-sizes"
+    new_col_name = col + " differentials"
     concat_diffs.rename(columns={col: new_col_name}, inplace=True)
 
 concat_diffs.to_csv(snakemake.output[0], sep="\t", index=True)

--- a/qadabra/workflow/scripts/concatenate_differentials.py
+++ b/qadabra/workflow/scripts/concatenate_differentials.py
@@ -19,9 +19,5 @@ diffs_files = [
 ]
 concat_diffs = pd.concat(diffs_files, axis=1)
 
-for col in concat_diffs.columns:
-    new_col_name = col + " differentials"
-    concat_diffs.rename(columns={col: new_col_name}, inplace=True)
-
 concat_diffs.to_csv(snakemake.output[0], sep="\t", index=True)
 logger.info(f"Saved to {snakemake.output[0]}")

--- a/qadabra/workflow/scripts/concatenate_differentials.py
+++ b/qadabra/workflow/scripts/concatenate_differentials.py
@@ -1,7 +1,5 @@
 import logging
-
 import pandas as pd
-
 
 logger = logging.getLogger("qadabra")
 logger.setLevel(logging.INFO)
@@ -20,5 +18,10 @@ diffs_files = [
     pd.read_table(x, sep="\t", index_col=0) for x in snakemake.input
 ]
 concat_diffs = pd.concat(diffs_files, axis=1)
+
+for col in concat_diffs.columns:
+    new_col_name = col + "_effect-sizes"
+    concat_diffs.rename(columns={col: new_col_name}, inplace=True)
+
 concat_diffs.to_csv(snakemake.output[0], sep="\t", index=True)
 logger.info(f"Saved to {snakemake.output[0]}")

--- a/qadabra/workflow/scripts/concatenate_pvalues.py
+++ b/qadabra/workflow/scripts/concatenate_pvalues.py
@@ -1,7 +1,5 @@
 import logging
-
 import pandas as pd
-
 
 logger = logging.getLogger("qadabra")
 logger.setLevel(logging.INFO)
@@ -16,9 +14,14 @@ logging.captureWarnings(True)
 logging.getLogger("py.warnings").addHandler(fh)
 
 logger.info("Loading p-values...")
-diffs_files = [
+pvalue_files = [
     pd.read_table(x, sep="\t", index_col=0) for x in snakemake.input
 ]
-concat_diffs = pd.concat(diffs_files, axis=1)
-concat_diffs.to_csv(snakemake.output[0], sep="\t", index=True)
+concat_pvalues = pd.concat(pvalue_files, axis=1)
+
+for col in concat_pvalues.columns:
+    new_col_name = col + "_p-values"
+    concat_pvalues.rename(columns={col: new_col_name}, inplace=True)
+
+concat_pvalues.to_csv(snakemake.output[0], sep="\t", index=True)
 logger.info(f"Saved to {snakemake.output[0]}")

--- a/qadabra/workflow/scripts/concatenate_pvalues.py
+++ b/qadabra/workflow/scripts/concatenate_pvalues.py
@@ -20,7 +20,7 @@ pvalue_files = [
 concat_pvalues = pd.concat(pvalue_files, axis=1)
 
 for col in concat_pvalues.columns:
-    new_col_name = col + "_p-values"
+    new_col_name = col + " p-values"
     concat_pvalues.rename(columns={col: new_col_name}, inplace=True)
 
 concat_pvalues.to_csv(snakemake.output[0], sep="\t", index=True)

--- a/qadabra/workflow/scripts/concatenate_pvalues.py
+++ b/qadabra/workflow/scripts/concatenate_pvalues.py
@@ -19,9 +19,5 @@ pvalue_files = [
 ]
 concat_pvalues = pd.concat(pvalue_files, axis=1)
 
-for col in concat_pvalues.columns:
-    new_col_name = col + " p-values"
-    concat_pvalues.rename(columns={col: new_col_name}, inplace=True)
-
 concat_pvalues.to_csv(snakemake.output[0], sep="\t", index=True)
 logger.info(f"Saved to {snakemake.output[0]}")

--- a/qadabra/workflow/scripts/process_pvalues.py
+++ b/qadabra/workflow/scripts/process_pvalues.py
@@ -13,8 +13,8 @@ logger.addHandler(fh)
 logger.info(f"Loading {snakemake.wildcards['tool']} p-values...")
 col = snakemake.params["col"]
 logger.info(f"Using '{col}' as column")
-diffs = pd.read_table(snakemake.input[0], sep="\t", index_col=0)[col]
-diffs.name = snakemake.wildcards["tool"]
-diffs.index.name = "feature_id"
-diffs.to_csv(snakemake.output[0], sep="\t", index=True)
+pvalues = pd.read_table(snakemake.input[0], sep="\t", index_col=0)[col]
+pvalues.name = snakemake.wildcards["tool"]
+pvalues.index.name = "feature_id"
+pvalues.to_csv(snakemake.output[0], sep="\t", index=True)
 logger.info(f"Saved to {snakemake.output[0]}")


### PR DESCRIPTION
Addressing this FutureWarning from Pandas:

utils.py:53: FutureWarning: The default value of numeric_only in DataFrameGroupBy.sum is deprecated. In a future version, numeric_only will default to False. Either specify numeric_only or select only columns which should be valid for the function.
gb = joint_df.groupby(factor_name).sum()

See documentation updates: https://pandas.pydata.org/docs/whatsnew/v1.5.0.html